### PR TITLE
新規ユーザー作成のAPIの実装

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"KCLHack-PU-Back/database"
+	"KCLHack-PU-Back/services"
 
 	"github.com/labstack/echo/v4"
 )
@@ -21,6 +22,13 @@ func connect(c echo.Context) error {
 
 func main() {
 	e := echo.New()
+
+	// POST
+	e.POST("/create/user", services.NewUser)
+
+	// GET
 	e.GET("/", connect)
+
+
 	e.Logger.Fatal(e.Start(":8080"))
 }

--- a/services/new_user.go
+++ b/services/new_user.go
@@ -1,0 +1,39 @@
+package services
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+
+	"KCLHack-PU-Back/database"
+	"KCLHack-PU-Back/crud"
+)
+
+func NewUser(c echo.Context) error {
+
+
+	user := database.User{}
+	type body struct {
+		Name string `json:"name"`
+	}
+	obj := body{}
+
+	if err := c.Bind(&obj); err != nil {
+		return err;
+	}
+	user.Name = obj.Name
+
+	if user.Name == "" {
+		return echo.NewHTTPError(http.StatusBadRequest, "User name is required.")
+	}
+
+	user = crud.CreateUserDB(user)
+
+	if user.ID == 0 {
+		return echo.NewHTTPError(http.StatusConflict, "This username is already exist.")
+	}
+
+	return c.JSON(http.StatusCreated, user)
+
+
+}


### PR DESCRIPTION
新しいユーザーを作成するAPIを作りました。
ここに書くことじゃないかもしれないけど
自分の環境ではcreate_post.goのimportのところで
"KCL-Hack2024-PU-Back/database"を"KCLHack-PU-Back/database"に書き換えたら動きました。
（このimportの書き換えはプルリクに含めてないです）