### PR TITLE
他人のユーザーの投稿を変更できないように修正

### DIFF
--- a/services/update_post.go
+++ b/services/update_post.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"github.com/labstack/echo/v4"
+	"github.com/golang-jwt/jwt/v5"
 
 	"KCLHack-PU-Back/crud"
 	"net/http"
@@ -15,6 +16,10 @@ func UpdatePost(c echo.Context) error {
 		Importance uint      `json:"importance"`
 		Deadline   string    `json:"deadline"`
 	}
+
+	user := c.Get("user").(*jwt.Token)
+    claims := user.Claims.(jwt.MapClaims)
+    userName := claims["name"].(string)
 
 	idStr := c.Param("postId")
 	id, err := strconv.ParseUint(idStr, 10, 32)
@@ -32,6 +37,10 @@ func UpdatePost(c echo.Context) error {
 
 	if err != nil {
 		return err
+	}
+
+	if post.UserName != userName {
+		return echo.NewHTTPError(http.StatusInternalServerError, "you can't update this post")
 	}
 
 	post = crud.ChangePost(post, obj.Task, obj.Importance, obj.Deadline)


### PR DESCRIPTION
投稿を削除する際はトークンに含まれるユーザー名と投稿した人のユーザー名が一致するときのみに、投稿を削除できるようにしました。